### PR TITLE
Fix alignment, make AI moves take at least 1 second

### DIFF
--- a/src/ai/Strategy.js
+++ b/src/ai/Strategy.js
@@ -1,0 +1,19 @@
+import { sleep } from './utils'
+
+const MINIMUM_WAIT_TIME = 1000
+
+class Strategy {
+  async determineMove(board, marker) {
+    const start = new Date()
+    const bestMove = this.findBestMove(board, marker)
+    const end = new Date()
+    const duration = end - start
+    // Wait for a minimum of 1 second to give the impression of the computer "thinking"
+    const waitTime = Math.max(MINIMUM_WAIT_TIME - duration, 1)
+    await sleep(waitTime)
+    return bestMove
+  }
+  findBestMove(board, marker) {}
+}
+
+export default Strategy

--- a/src/ai/StrategyBeatable.js
+++ b/src/ai/StrategyBeatable.js
@@ -1,10 +1,10 @@
 import { determineOutcome, opposingMarker, randomMove } from '../logic'
-import { getAvailableMoveIndices, sleep } from './utils'
+import { getAvailableMoveIndices } from './utils'
+import Strategy from './Strategy'
 
-export class StrategyBeatable {
+export class StrategyBeatable extends Strategy {
   static title = 'Intermediate'
-  async determineMove(board, marker) {
-    await sleep(1000)
+  findBestMove(board, marker) {
     let winningMove, blockingMove
     const moves = getAvailableMoveIndices(board)
     moves.forEach((move) => {

--- a/src/ai/StrategyRandom.js
+++ b/src/ai/StrategyRandom.js
@@ -1,10 +1,9 @@
 import { randomMove } from '../logic'
-import { sleep } from './utils'
+import Strategy from './Strategy'
 
-export class StrategyRandom {
+export class StrategyRandom extends Strategy {
   static title = 'Novice'
-  async determineMove(board, marker) {
-    await sleep(1000)
+  findBestMove(board, marker) {
     return randomMove(board)
   }
 }

--- a/src/ai/StrategyUnbeatable.js
+++ b/src/ai/StrategyUnbeatable.js
@@ -1,6 +1,7 @@
 import { determineOutcome, opposingMarker } from '../logic'
 import { CATS_GAME, MARKER_O, MARKER_X } from '../constants'
-import { getAvailableMoveIndices, sleep } from './utils'
+import { getAvailableMoveIndices } from './utils'
+import Strategy from './Strategy'
 
 function getScore(board) {
   const outcome = determineOutcome(board)
@@ -54,11 +55,9 @@ function minimax(node, marker) {
   return bestMove
 }
 
-export class StrategyUnbeatable {
+export class StrategyUnbeatable extends Strategy {
   static title = 'Unbeatable'
-  async determineMove(board, marker) {
-    // this one can take a while so don't fake for as long
-    await sleep(500)
+  findBestMove(board, marker) {
     const bestMove = minimax({ board }, marker)
     return bestMove.index
   }

--- a/src/ui/components/GameControls.js
+++ b/src/ui/components/GameControls.js
@@ -32,6 +32,7 @@ const useStyles = makeStyles((theme) => ({
   },
   restart: {
     height: 24,
+    padding: 0,
   },
   loading: {
     color: theme.palette.primary.contrastText,


### PR DESCRIPTION
## Bugfix 
On mobile devices, the Restart button alignment was off. Fixed this by removing padding for that button.

## AI response time
Previously I had added a couple of `async sleep(1000)` to the primitive AI strategies, and a `sleep(500)` to the Unbeatable minimax strategy. However, since Minimax's runtime varies widely, a better solution would be to detect the best move, then delay resolution until a certain minimum move time has elapsed. 

This PR adds that functionality by way of adding a Strategy.js base class, which wraps the asynchronous wait time logic and allows child class strategies to simply implement the `findBestMove` method. 